### PR TITLE
Added cdn.jsdelivr.net to csp style directive

### DIFF
--- a/svelte.config.ts
+++ b/svelte.config.ts
@@ -28,7 +28,7 @@ export default {
     csp: {
       mode: 'auto',
       directives: {
-        'style-src': ['self', 'unsafe-inline', 'https://giscus.app']
+        'style-src': ['self', 'unsafe-inline', 'https://giscus.app', 'https://cdn.jsdelivr.net']
       }
     }
   }


### PR DESCRIPTION
[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) was blocking the katex css from loading from the CDN. I have added cdn.jsdelivr.net to the allowed list.

Alternatively, consider hosting the css file locally